### PR TITLE
Fix video autoplay on mobile and correct source type

### DIFF
--- a/src/_includes/layouts/project.html
+++ b/src/_includes/layouts/project.html
@@ -255,8 +255,9 @@
 
                         <a href="{{ nextPost.url }}" class="project-bg">
                             {% if nextPost.data.cover_video %}
-                            <video autoplay muted loop playsinline preload="metadata">
-                                <source src="{{ nextPost.data.cover_video }}" type="video/mp4">
+                            {% set nextPoster = nextPost.data.fti or nextPost.data.image or nextPost.data.bg or nextPost.data.fi %}
+                            <video autoplay muted loop playsinline preload="metadata"{% if nextPoster %} poster="{{ nextPoster }}"{% endif %}>
+                                <source src="{{ nextPost.data.cover_video }}" type="video/webm">
                             </video>
                             {% else %}
                             <div class="bg-img" style="background-image:url('{{ nextMedia }}')"></div>
@@ -281,8 +282,9 @@
 
                         <a href="{{ prevPost.url }}" class="project-bg">
                             {% if prevPost.data.cover_video %}
-                            <video autoplay muted loop playsinline preload="metadata">
-                                <source src="{{ prevPost.data.cover_video }}" type="video/mp4">
+                            {% set prevPoster = prevPost.data.fti or prevPost.data.image or prevPost.data.bg or prevPost.data.fi %}
+                            <video autoplay muted loop playsinline preload="metadata"{% if prevPoster %} poster="{{ prevPoster }}"{% endif %}>
+                                <source src="{{ prevPost.data.cover_video }}" type="video/webm">
                             </video>
                             {% else %}
                             <div class="bg-img" style="background-image:url('{{ prevMedia }}')"></div>

--- a/src/assets/js/nav.js
+++ b/src/assets/js/nav.js
@@ -292,6 +292,15 @@ document.addEventListener('DOMContentLoaded', function () {
 // });
 
 
+// MOBILE AUTOPLAY FIX
+document.addEventListener("DOMContentLoaded", function () {
+  document.querySelectorAll('video[autoplay]').forEach(video => {
+    video.play().catch(() => {
+      // Autoplay blocked — poster image will show as fallback
+    });
+  });
+});
+
 // CUSTOM VIDEO PLAYER
 
 document.addEventListener("DOMContentLoaded", function () {

--- a/src/index.html
+++ b/src/index.html
@@ -168,8 +168,8 @@ eleventyNavigation:
                                 {% if media_type == "Video" and cover_video %}
                                     <div class="blog-mainMedia intro-image">
                                         <a href="{{ post.url }}">
-                                            <video autoplay muted loop playsinline preload="metadata">
-                                                <source src="{{ cover_video }}" type="video/mp4">
+                                            <video autoplay muted loop playsinline preload="metadata"{% if fti %} poster="{{ fti }}"{% endif %}>
+                                                <source src="{{ cover_video }}" type="video/webm">
                                             </video>
                                         </a>
                                     </div>


### PR DESCRIPTION
## Summary
- Fixed `type="video/mp4"` to `type="video/webm"` for `.webm` video sources across homepage and project nav cards
- Added `poster` attribute on `<video>` elements so a thumbnail image displays when autoplay is blocked
- Added JavaScript to force `.play()` on autoplay videos for mobile browsers (especially iOS Safari) that suppress autoplay even when muted

## Test plan
- [ ] Verify video autoplays on desktop browsers
- [ ] Test on iOS Safari — video should attempt autoplay; if blocked, poster image should display
- [ ] Test on Android Chrome — same behavior
- [ ] Check project nav cards (next/prev) render video correctly with poster fallback

🤖 Generated with [Claude Code](https://claude.com/claude-code)